### PR TITLE
fix: support ruby 2.7 due to Dir.glob sort issue

### DIFF
--- a/lib/github_contributions.rb
+++ b/lib/github_contributions.rb
@@ -6,7 +6,7 @@ require "octokit"
 require "hashie"
 require "digest"
 
-Dir.glob(File.dirname(__FILE__) + '/github_contributions/**/*.rb') { |file| require file  }
+Dir.glob(File.dirname(__FILE__) + '/github_contributions/**/*.rb').sort.each { |file| require file }
 
 module GithubContributions
   class << self


### PR DESCRIPTION
In ruby 3.x `Dir.glob` is sorted, while in 2.x it isn't. This causes load
ordering issues.
